### PR TITLE
Fix template not found error after go install

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -8,7 +8,7 @@ import (
 
 func prepareProgram(templatePath string, commands []command, functions []function) (string, error) {
 	// Read the template file
-	t := template.Must(template.New("template.txt").ParseFiles(templatePath))
+	t := template.Must(template.New("template.txt").Parse(programTemplate))
 	var buf bytes.Buffer
 	err := t.Execute(&buf, map[string]interface{}{
 		"commands":  commands,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ahmedakef/goshell
+module github.com/MahmoudYounes/goshell
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MahmoudYounes/goshell
+module github.com/ahmedakef/goshell
 
 go 1.21
 

--- a/template.go
+++ b/template.go
@@ -1,4 +1,7 @@
 package main
+
+var programTemplate =`
+package main
 {{range .functions}}
     {{.Src}}
 {{end}}
@@ -15,4 +18,4 @@ func use(vals ...interface{}) {
     for _, val := range vals {
         _ = val
     }
-}
+}`


### PR DESCRIPTION
Fixes #1 
This PR makes the goshell app self contained by changing the template.txt file to a template.go file that gets compiled into the binary. this way once users make a go install to the REPL they don't face the error that happens when runProgram is called.